### PR TITLE
fix: Add compatibility symlink for libtiff6 in Linux dependencies setup

### DIFF
--- a/.github/actions/setup-dependencies/linux/action.yml
+++ b/.github/actions/setup-dependencies/linux/action.yml
@@ -15,6 +15,14 @@ runs:
           openjdk-17-jdk \
           libtiff6
 
+        # Qt imageformat plugin was looking for libtiff.so.5; we standardize on libtiff6 and expose compat symlink.
+        archdir="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
+        if [ -e "/usr/lib/$archdir/libtiff.so.6" ] && [ ! -e "/usr/lib/$archdir/libtiff.so.5" ]; then
+          sudo ln -sf /usr/lib/$archdir/libtiff.so.6 /usr/lib/$archdir/libtiff.so.5
+          sudo ldconfig
+          echo ":warning: libtiff6 installed; created libtiff.so.5 compat symlink to libtiff6" >> "$GITHUB_STEP_SUMMARY"
+        fi
+
     - name: Set JAVA_HOME
       shell: bash
       run: |


### PR DESCRIPTION
# Project Tick - ProjT Launcher Pull Request

## Description
<!-- Summarize the changes and why they are needed. -->

## Type of Change

- [X] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [X] Build / CI
- [ ] Other

## Checklist

- [x] I have read the contributing guidelines.
- [ ] My code follows the project's style guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation accordingly.

## Related Issues
<!-- Link to any related issues, e.g., `Fixes #123` -->

## Additional Notes
<!-- Any additional information, screenshots, or context. -->

## Signed-off-by
<!-- Please use signed-off-by: name <email> -->
