### PR TITLE
fix: update macOS build environment to use macos-14 instead of macos-…

### DIFF
--- a/.github/workflows/build-projt-launcher.yml
+++ b/.github/workflows/build-projt-launcher.yml
@@ -737,7 +737,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14-xlarge
+          - os: macos-14
             artifact-name: macOS
             cmake-preset: macos_universal
             macosx-deployment-target: 12.0


### PR DESCRIPTION
…14-xlarge and rerelease 0.0.4-1

# Project Tick - ProjT Launcher Pull Request

## Description
<!-- Summarize the changes and why they are needed. -->

## Scope
<!-- Select all that apply. CI/jobs may be filtered based on this selection. -->

- [ ] Launcher (C++/Qt)
- [ ] Website (Eleventy)
- [ ] Bot (Cloudflare Workers)
- [ ] Metadata Generator (Python)
- [ ] Quazip
- [ ] bzip2
- [ ] Docs
- [ ] CI
- [ ] Tools
- [ ] Branding
- [ ] Launcher Java System
- [ ] JavaCheck
- [ ] libnbtplusplus
- [ ] Zlib
- [ ] libqrencode
- [ ] cmark
- [ ] tomlplusplus
- [ ] Packages
- [ ] Other (describe):

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Build / CI
- [ ] Chore

## If you are selected packages scope, please select Package Types
<!-- Required when "Packages" is selected above. -->

- [ ] NixOS
- [ ] Flatpak
- [ ] AUR
- [ ] Add a new package manifest

## Checklist

- [ ] I have read `CONTRIBUTING.md`.
- [ ] My code follows the project's style guidelines.
- [ ] I have added tests that prove my fix is effective or explained why not.
- [ ] All new and existing tests pass or I explained why not.
- [ ] I have updated documentation accordingly or confirmed it is not needed.
- [ ] DCO: each commit includes `Signed-off-by:`

## Related Issues
<!-- Link to any related issues, e.g., `Fixes #123` -->

## Additional Notes
<!-- Any additional information, screenshots, or context. -->

## Signed-off-by
<!-- Please use signed-off-by: name <email> -->
