### PR TITLE
fix: remove Flatpak build job from CI workflow

### DIFF
--- a/.github/workflows/build-projt-launcher.yml
+++ b/.github/workflows/build-projt-launcher.yml
@@ -821,57 +821,6 @@ jobs:
           apple-notarize-password: ${{ secrets.APPLE-NOTARIZE_PASSWORD }}
           sparkle-ed25519-key: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
 
-  flatpak-build:
-    name: Flatpak Build (${{ matrix.arch }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            arch: x86_64
-
-          - os: ubuntu-24.04-arm
-            arch: aarch64
-
-    runs-on: ${{ matrix.os }}
-
-    container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.10
-      options: --privileged
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ env.CHECKOUT_REF }}
-          submodules: true
-
-      - name: Set short version
-        id: short-version
-        shell: bash
-        run: |
-          echo "version=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          echo "VERSION=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
-
-      - name: Free disk space
-        shell: bash
-        run: |
-          df -h
-          rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/powershell /usr/share/swift || true
-          rm -rf /var/lib/apt/lists/* /var/cache/apt/* || true
-          if command -v apt-get >/dev/null 2>&1; then
-            apt-get clean || true
-          fi
-          df -h
-
-      - name: Build Flatpak
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
-        with:
-          bundle: ProjTLauncher-${{ runner.os }}-${{ steps.short-version.outputs.version }}-Flatpak.flatpak
-          manifest-path: flatpak/org.projecttick.ProjTLauncher.yml
-          arch: ${{ matrix.arch }}
-
   nix-system-build:
     name: Build via Nix (${{ matrix.system }})
     needs: [flake-check]


### PR DESCRIPTION
# Project Tick - ProjT Launcher Pull Request

## Description
<!-- Summarize the changes and why they are needed. -->

## Scope
<!-- Select all that apply. CI/jobs may be filtered based on this selection. -->

- [ ] Launcher (C++/Qt)
- [ ] Website (Eleventy)
- [ ] Bot (Cloudflare Workers)
- [ ] Metadata Generator (Python)
- [ ] Quazip
- [ ] bzip2
- [ ] Docs
- [ ] CI
- [ ] Tools
- [ ] Branding
- [ ] Launcher Java System
- [ ] JavaCheck
- [ ] libnbtplusplus
- [ ] Zlib
- [ ] libqrencode
- [ ] cmark
- [ ] tomlplusplus
- [ ] Packages
- [ ] Other (describe):

## Type of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Build / CI
- [ ] Chore

## If you are selected packages scope, please select Package Types
<!-- Required when "Packages" is selected above. -->

- [ ] NixOS
- [ ] Flatpak
- [ ] AUR
- [ ] Add a new package manifest

## Checklist

- [ ] I have read `CONTRIBUTING.md`.
- [ ] My code follows the project's style guidelines.
- [ ] I have added tests that prove my fix is effective or explained why not.
- [ ] All new and existing tests pass or I explained why not.
- [ ] I have updated documentation accordingly or confirmed it is not needed.
- [ ] DCO: each commit includes `Signed-off-by:`

## Related Issues
<!-- Link to any related issues, e.g., `Fixes #123` -->

## Additional Notes
<!-- Any additional information, screenshots, or context. -->

## Signed-off-by
<!-- Please use signed-off-by: name <email> -->
